### PR TITLE
Update setup script to make setup more seamless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= buildah
+CONTAINER_TOOL ?= docker
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= buildah
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,12 +21,9 @@ This directory contains a simplified Vagrant setup for testing the live pod migr
 # From the vagrant directory
 cd vagrant/
 
-# Start both nodes (master first, then worker)
-vagrant up master
-vagrant up worker
+# Run setup cluster script (this will first bring up master then worker)
+./setup-cluster.sh
 
-# Or start both at once
-vagrant up
 ```
 
 ### 2. Verify Cluster
@@ -51,9 +48,9 @@ kubectl get service nginx
 cd /home/vagrant/live-pod-migration-controller
 
 # Build and deploy the controller
-make docker-build IMG=controller:latest
-make docker-build-agent AGENT_IMG=checkpoint-agent:latest
-make deploy IMG=controller:latest
+sudo make docker-build IMG=controller:latest CONTAINER_TOOL=buildah
+sudo make docker-build-agent AGENT_IMG=checkpoint-agent:latest CONTAINER_TOOL=buildah
+sudo make deploy IMG=controller:latest
 
 # Verify deployment
 kubectl get pods -n live-pod-migration-controller-system

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,6 +4,9 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-22.04"
   
+  # Configure a tmp bi-directional sync folder
+  config.vm.synced_folder ".","/tmp_sync"
+
   # Explicitly configure the /vagrant shared folder with rsync
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
   

--- a/vagrant/scripts/common.sh
+++ b/vagrant/scripts/common.sh
@@ -189,6 +189,6 @@ echo 'export PATH=$PATH:/home/vagrant/go/bin' >> /home/vagrant/.bashrc
 
 # Disable swap (required for Kubernetes)
 sudo swapoff -a
-sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+sudo sed -i '/\bswap\b/s/^/#/' /etc/fstab
 
 echo "Common setup completed successfully!"

--- a/vagrant/scripts/master.sh
+++ b/vagrant/scripts/master.sh
@@ -21,10 +21,14 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
+controlPlaneEndpoint: 192.168.56.10:6443
 networking:
   podSubnet: 10.244.0.0/16
 apiServer:
   advertiseAddress: 192.168.56.10
+  certSANs:
+    - 192.168.56.10
+    - 10.0.2.15
 EOF
 
 # Reset any previous failed installations
@@ -87,6 +91,8 @@ echo "Removing control-plane taint..."
 kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 
 # Note: Join command will be retrieved directly by worker when needed
+kubeadm token create --print-join-command > /tmp_sync/setup.sh
+chmod +x /tmp_sync/setup.sh
 echo "Master ready for worker nodes to join..."
 
 # Set up Go tools for development

--- a/vagrant/scripts/worker.sh
+++ b/vagrant/scripts/worker.sh
@@ -4,30 +4,16 @@ set -euxo pipefail
 
 # Note: common.sh is run separately by Vagrant, no need to source it here
 
-# Wait for master to be ready and get join command
-echo "Waiting for master node to be ready..."
-MAX_ATTEMPTS=60
-ATTEMPT=0
-
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-  # Try to get join command directly from master via SSH
-  JOIN_CMD=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR vagrant@192.168.56.10 "kubeadm token create --print-join-command 2>/dev/null" 2>/dev/null || true)
-  
-  if [ ! -z "$JOIN_CMD" ] && [[ "$JOIN_CMD" == *"kubeadm join"* ]]; then
-    echo "Got join command from master, joining cluster..."
-    sudo $JOIN_CMD
-    break
-  fi
-  
-  echo "Master not ready yet, attempt $ATTEMPT/$MAX_ATTEMPTS..."
-  ATTEMPT=$((ATTEMPT + 1))
-  sleep 10
+# Wait for join command to be available
+while [ ! -f /tmp_sync/setup.sh ]; do
+  echo "Waiting for join command..."
+  sleep 5
 done
 
-if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
-  echo "ERROR: Could not get join command from master after $MAX_ATTEMPTS attempts"
-  echo "You may need to join manually with: kubeadm token create --print-join-command (on master)"
-  exit 1
-fi
+# Join the cluster
+sudo bash /tmp_sync/setup.sh
+
+# Remove the script
+sudo rm /tmp_sync/setup.sh
 
 echo "Worker node setup completed successfully!"

--- a/vagrant/setup-cluster.sh
+++ b/vagrant/setup-cluster.sh
@@ -21,22 +21,9 @@ fi
 
 echo "Master node is ready!"
 
-# Get join command from master
-echo "Getting join command from master..."
-JOIN_CMD=$(vagrant ssh master -c "kubeadm token create --print-join-command" 2>/dev/null)
-
-if [ -z "$JOIN_CMD" ]; then
-    echo "ERROR: Could not get join command from master"
-    exit 1
-fi
-
 # Start worker
 echo "Starting worker node..."
 vagrant up worker
-
-# Join worker to cluster
-echo "Joining worker to cluster..."
-vagrant ssh worker -c "sudo $JOIN_CMD"
 
 # Verify cluster
 echo "Verifying cluster status..."


### PR DESCRIPTION
What is part of this change?
- Update sed command in `common.sh` where we update `/etc/fstab` to always comment out swap so that machine always boot with swap off (previous one was not generic enough to match all cases)
- Added a tmp folder that is bi-directionally sync-ed, currently using this folder only to sync the `setup.sh` script that worker node will call to join the cluster. 
  - The current version where we store the command in a temporary bash variable `JOIN_CMD` does not work, as the command contains spaces and the variable expansion `$JOIN_CMD` cannot be done properly (even if we use escape sequences, the token might contain some special characters that will break variable expansion, hence I think sharing a file is the best solution here)
- Added a `controlPlaneEndpoint` in the kube-config and set to the private ip address of master node (that is accessible by worker). This change was needed as the `kubeadm token create` command was creating the command using the NAT interface address (10.0.2.15), which was not accessible by worker node.
- Updated the README instructions on setting up
  - Use `sudo` when building images using buildah, this would allow the built image to be discoverable by `crio` and could be pulled when we run deploy 

My changes should now enable provisioning of the VMs and kubernetes cluster simply by running the `setup-cluster.sh` script, as well as building images and deploying pods within the cluster. 